### PR TITLE
Components (Sales & Work Manaement) and Website (Xolve Group) addition on Add-ons page

### DIFF
--- a/screen/moqui.org/addons.html
+++ b/screen/moqui.org/addons.html
@@ -103,7 +103,7 @@
                             Test credentails:- Username- customer@noiexams.com & Password- 123456</td>
                     </tr>
                     <tr>
-                        <td><a href="www.xolvegroup.com" target="_blank">www.xolvegroup.com</a></td>
+                        <td><a href="https://www.xolvegroup.com" target="_blank">Xolve Group</a></td>
                         <td>moqui-framework, runtime, udm/usl, wiki, requests, REST services</td>
                         <td>The Xolve Group website is built using Quasar, powered by content from the Moqui wiki and integrated via REST services.</td>
                     </tr>

--- a/screen/moqui.org/addons.html
+++ b/screen/moqui.org/addons.html
@@ -54,6 +54,20 @@
                         <td></td>
                         <td>Moqui component with localization data for German translations</td>
                     </tr>
+                    <tr>
+                        <td><a href="https://github.com/xolvegroup/Sales" target="_blank">Sales</a></td>
+                        <td><a href="http://creativecommons.org/publicdomain/zero/1.0/">CC0</a></td>
+                        <td>Application</td>
+                        <td>mantle-usl, mantle-udm, SimpleScreens</td>
+                        <td>CRM application that includes accounts, contacts, opportunities, and quotes.</td>
+                    </tr>
+                    <tr>
+                        <td><a href="https://github.com/xolvegroup/WorkManagement" target="_blank">Work Management</a></td>
+                        <td><a href="http://creativecommons.org/publicdomain/zero/1.0/">CC0</a></td>
+                        <td>Application</td>
+                        <td>mantle-usl, mantle-udm, SimpleScreens</td>
+                        <td>Project and task management</td>
+                    </tr>
                 </tbody>
             </table>
         </div>
@@ -87,6 +101,11 @@
                         <td>moqui-framework/runtime, mantle-udm/usl, SimpleScreens</td>
                         <td>SMS Express provides solution to send messages to multiple users with simple and user-friendly UI in India.
                             Test credentails:- Username- customer@noiexams.com & Password- 123456</td>
+                    </tr>
+                    <tr>
+                        <td><a href="www.xolvegroup.com" target="_blank">www.xolvegroup.com</a></td>
+                        <td>moqui-framework, runtime, udm/usl, wiki, requests, REST services</td>
+                        <td>The Xolve Group website is built using Quasar, powered by content from the Moqui wiki and integrated via REST services.</td>
                     </tr>
                 </tbody>
             </table>


### PR DESCRIPTION
Updated the addons.html page to include 2 components named Sales & Work Management under the "Add-on Component Directory" section and one website named "Xolve Group" under the "Web Sites built with Moqui" section.