### PR TITLE
Update moqui-org-compose.yml

### DIFF
--- a/docker/moqui-org-compose.yml
+++ b/docker/moqui-org-compose.yml
@@ -26,8 +26,8 @@ services:
     container_name: nginx-proxy
     restart: always
     ports:
-      - 80:80
-      - 443:443
+      - 0.0.0.0:80:80
+      - 0.0.0.0:443:443
     volumes:
       - /var/run/docker.sock:/tmp/docker.sock:ro
       # note: .crt, .key, and .dhparam.pem files start with the domain name in VIRTUAL_HOST (ie 'moqui.local.*') or use CERT_NAME env var
@@ -38,6 +38,26 @@ services:
       - DEFAULT_HOST=moqui.org
       # use SSL_POLICY to disable TLSv1.0, etc in nginx-proxy
       # - SSL_POLICY=AWS-TLS-1-1-2017-01
+    networks:
+      - nginx-proxy
+
+# If you're want to use automated SSL certificates
+#  acme-companion:
+#    image: nginxproxy/acme-companion
+#    container_name: acme-companion
+#    environment:
+#      - DEFAULT_EMAIL=example@changeme.com
+#      - ACME_CA_URI=https://acme.zerossl.com/v2/DV90
+#      - RENEW_PRIVATE_KEYS=false
+#      - CERTS_UPDATE_INTERVAL=5
+#    volumes_from:
+#      - nginx-proxy
+#    volumes:
+#      - ./certs:/etc/nginx/certs:rw
+#      - ./acme:/etc/acme.sh
+#      - /var/run/docker.sock:/var/run/docker.sock:ro
+#    networks:
+#      - nginx-proxy
 
   # --- DEMO ---
   moqui-demo:
@@ -59,6 +79,8 @@ services:
       - webapp_client_ip_header=CF-Connecting-IP
       - default_locale=en_US
       - default_time_zone=US/Pacific
+    networks:
+      - nginx-proxy
 
   # --- ORG ---
   moqui-org:
@@ -106,6 +128,8 @@ services:
      - webapp_client_ip_header=CF-Connecting-IP
      - default_locale=en_US
      - default_time_zone=US/Pacific
+    networks:
+      - nginx-proxy
 
   moqui-database:
     image: postgres:14.5
@@ -123,6 +147,8 @@ services:
      - POSTGRES_USER=moqui
      - POSTGRES_PASSWORD=moqui
      # PGDATA, POSTGRES_INITDB_ARGS
+    networks:
+      - nginx-proxy
 
   moqui-search:
     image: opensearchproject/opensearch:2.4.0
@@ -148,6 +174,8 @@ services:
       nofile:
         soft: 65536
         hard: 65536
+    networks:
+      - nginx-proxy
 
   opensearch-dashboards:
     image: opensearchproject/opensearch-dashboards:2.4.0
@@ -160,3 +188,11 @@ services:
       - 127.0.0.1:5601:5601
     environment:
       OPENSEARCH_HOSTS: '["https://moqui-search:9200"]'
+    networks:
+      - nginx-proxy
+
+networks:
+  nginx-proxy:
+    name: nginx-proxy
+    driver: bridge
+    attachable: true


### PR DESCRIPTION
On the server, run the following after you've run the `moqui-org-compose.yml` with proper credentials and setup:
NOTE: Based on this first: https://github.com/discourse/discourse/blob/main/docs/INSTALL-cloud.md then this https://meta.discourse.org/t/restore-a-backup-from-the-command-line/108034

## Migration Prerequisites
1. Go to: https://forum.moqui.org/admin/backups
2. Put the production database into read only mode
3. Create a database backup
4. Download the database backup
5. Setup the DNS records to point to the new server
6. Setup the ssl cert

## Code Setup
1. Go to new server. 
2. Ensure that the docker engine and git are installed
3.  Install Discourse
```bash
sudo -s
git clone https://github.com/discourse/discourse_docker.git /var/discourse
cd /var/discourse
chmod 700 containers
```
4. Move exsiting app.yml to /var/discourse/containers (See link in message or ask for example)
Note: If there is no app.yml, run in `/var/discourse` with port 80 and 443 open (you may have to stop the moqui compose file temporarily just for building)
```bash
./discourse-setup
```
5. Configure the app.yml based on: https://meta.discourse.org/t/run-other-websites-on-the-same-machine-as-discourse/17247/244
6. Make sure to set the VIRTUAL_HOST environment variable
7. Run 
```bash
/var/discourse/launcher rebuild app --docker-args '--network nginx-proxy'
```
8. Ensure that forum.moqui.org is visible and accessible

## Migration
1. On the new server run:
```bash
mkdir -p /var/discourse/shared/standalone/backups/default
```
7. Put the exact file name and file data of the just recently created database backup into the /var/discourse/shared/standalone/backups/default directory. Example:
```bash
rsync -v moqui-forum-2024-06-20-033420-v20240202052058.tar.gz root@192.168.1.1:/var/discourse/shared/standalone/backups/default
```
9. Restore the Backup on the new server
```bash
# Access your destination server and go to the Discourse folder
cd /var/discourse

# Enter the Discourse Docker app container
./launcher enter app

# From inside the Docker container, enable restores via
discourse enable_restore

# Restore the backup file
discourse restore moqui-forum-2024-06-20-033420-v20240202052058.tar.gz 
```
10. Exit by running:
```bash
# Exit the Discourse Docker app container
exit
```
11. Rebuild
```bash
cd /var/discourse
./launcher rebuild app --docker-args '--network nginx-proxy'
```
12. Ensure that forum.moqui.org points to the new server, has the correct data, and you are able to login
13. Cleanup the old instance




